### PR TITLE
Support glob models path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,11 @@ ERD HTML is generated inside ``docs/``.
 ```php
 use Kevincobain2000\LaravelERD\LaravelERD;
 
-$namespace = 'App\Models\\';
 $modelsPath = base_path('app/Models');
 
 $laravelERD = new LaravelERD();
-$linkDataArray = $laravelERD->getLinkDataArray($namespace, $modelsPath);
-$nodeDataArray = $laravelERD->getNodeDataArray($namespace, $modelsPath);
+$linkDataArray = $laravelERD->getLinkDataArray($modelsPath);
+$nodeDataArray = $laravelERD->getNodeDataArray($modelsPath);
 $erdData = json_encode(
     [
         "link_data" => $linkDataArray,

--- a/config/laravel-erd.php
+++ b/config/laravel-erd.php
@@ -6,7 +6,6 @@ return [
         //Example
         //\App\Http\Middleware\NotFoundWhenProduction::class,
     ],
-    'namespace'        => 'App\Models\\',
     'models_path'      => base_path('app/Models'),
     'docs_path'        => base_path('docs/erd/'),
 

--- a/src/Commands/LaravelERDCommand.php
+++ b/src/Commands/LaravelERDCommand.php
@@ -27,13 +27,12 @@ class LaravelERDCommand extends Command
      */
     public function handle()
     {
-        $namespace       = config('laravel-erd.namespace') ?? 'App\Models\\';
         $modelsPath      = config('laravel-erd.models_path') ?? base_path('app/Models');
         $destinationPath = config('laravel-erd.docs_path') ?? base_path('docs/erd/');
 
         // extract data
-        $linkDataArray = $this->laravelERD->getLinkDataArray($namespace, $modelsPath);
-        $nodeDataArray = $this->laravelERD->getNodeDataArray($namespace, $modelsPath);
+        $linkDataArray = $this->laravelERD->getLinkDataArray($modelsPath);
+        $nodeDataArray = $this->laravelERD->getNodeDataArray($modelsPath);
 
         // pretty print array to json
         $docs = json_encode(
@@ -57,4 +56,3 @@ class LaravelERDCommand extends Command
         return 0;
     }
 }
-

--- a/src/Controllers/LaravelERDController.php
+++ b/src/Controllers/LaravelERDController.php
@@ -18,10 +18,9 @@ class LaravelERDController extends Controller
 
     public function index()
     {
-        $namespace       = config('laravel-erd.namespace') ?? 'App\Models\\';
         $modelsPath      = config('laravel-erd.models_path') ?? base_path('app/Models');
-        $linkDataArray   = $this->laravelERD->getLinkDataArray($namespace, $modelsPath);
-        $nodeDataArray   = $this->laravelERD->getNodeDataArray($namespace, $modelsPath);
+        $linkDataArray   = $this->laravelERD->getLinkDataArray($modelsPath);
+        $nodeDataArray   = $this->laravelERD->getNodeDataArray($modelsPath);
 
         // pretty print array to json
         $docs = json_encode(


### PR DESCRIPTION
In case some project has modular folder design for Models, it would be good to support glob models path. But since the config requires `namespace`, it can not make dynamic path working.

So what I have changed is to dynamically get namespace for each files. And then we can remove the config of `namespace`.