### PR TITLE
Makes routing property configurable

### DIFF
--- a/config/laravel-erd.php
+++ b/config/laravel-erd.php
@@ -11,6 +11,15 @@ return [
 
     "display" => [
         "show_data_type" => false,
+
+        /**
+         * Controls how the lines between models are drawn.
+         *
+         * Valid values are: Normal, Orthogonal, or AvoidsNodes.
+         *
+         * AvoidsNodes can be very slow in larger diagrams!
+         */
+        "routing" => 'AvoidsNodes',
     ],
 
     "from_text" => [

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -172,7 +172,7 @@ function init() {
               selectionAdorned: true,
               layerName: "Foreground",
               reshapable: true,
-              routing: go.Link.AvoidsNodes,
+              routing: go.Link.{{ $routingType }},
               corner: 5,
               curve: go.Link.Orthogonal,
               curviness: 0,

--- a/src/Commands/LaravelERDCommand.php
+++ b/src/Commands/LaravelERDCommand.php
@@ -34,20 +34,22 @@ class LaravelERDCommand extends Command
         $linkDataArray = $this->laravelERD->getLinkDataArray($modelsPath);
         $nodeDataArray = $this->laravelERD->getNodeDataArray($modelsPath);
 
-        // pretty print array to json
-        $docs = json_encode(
-            [
-                "link_data" => $linkDataArray,
-                "node_data" => $nodeDataArray,
-            ]
-        );
-
         if (! File::exists($destinationPath)) {
             File::makeDirectory($destinationPath, 0755, true);
         }
         File::put($destinationPath . '/index.html',
             view('erd::index')
-                ->with(compact('docs'))
+                ->with([
+                    'routingType' => config('laravel-erd.display.routing') ?? 'AvoidsNodes',
+
+                    // pretty print array to json
+                    'docs' => json_encode(
+                        [
+                            "link_data" => $linkDataArray,
+                            "node_data" => $nodeDataArray,
+                        ]
+                    ),
+                ])
                 ->render()
         );
 

--- a/src/Controllers/LaravelERDController.php
+++ b/src/Controllers/LaravelERDController.php
@@ -22,14 +22,17 @@ class LaravelERDController extends Controller
         $linkDataArray   = $this->laravelERD->getLinkDataArray($modelsPath);
         $nodeDataArray   = $this->laravelERD->getNodeDataArray($modelsPath);
 
-        // pretty print array to json
-        $docs = json_encode(
-            [
-                "link_data" => $linkDataArray,
-                "node_data" => $nodeDataArray,
-            ]
-        );
-        return view('erd::index')->with(compact('docs'));
+        return view('erd::index')->with([
+            'routingType' => config('laravel-erd.display.routing') ?? 'AvoidsNodes',
+
+            // pretty print array to json
+            'docs' => json_encode(
+                [
+                    "link_data" => $linkDataArray,
+                    "node_data" => $nodeDataArray,
+                ]
+            ),
+        ]);
     }
 
 }


### PR DESCRIPTION
This PR turns the routing property into a configurable parameter in the package. 

The `AvoidsNodes` option has extremely bad performance for my ER diagram. That seems like it might be something people run into often, so maybe this will be helpful? :-)

Although I don't know if you'd prefer to have folks customize the view that gets put in their app instead of making a bunch of config options. I'm also finding that I need to change the layout to `LayeredDigraphLayout` to make the diagram usable for my app.