### PR TITLE
Fix routes registering.

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Kevincobain2000\LaravelERD\Controllers\LaravelERDController;
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your package. These
+| routes are loaded by your package ServiceProvider within a group which
+| contains the "web" middleware group.
+|
+*/
+
+Route::get(config('laravel-erd.url'), [LaravelERDController::class, 'index'])
+    ->name('laravel-erd.index')
+    ->middleware(config('laravel-erd.middlewares'));

--- a/src/LaravelERDServiceProvider.php
+++ b/src/LaravelERDServiceProvider.php
@@ -15,10 +15,7 @@ class LaravelERDServiceProvider extends PackageServiceProvider
             ->name('laravel-erd')
             ->hasConfigFile('laravel-erd')
             ->hasViews()
-            ->hasCommand(LaravelERDCommand::class);
-
-        Route::get(config('laravel-erd.url'), [\Kevincobain2000\LaravelERD\Controllers\LaravelERDController::class, 'index'])
-            ->name('laravel-erd.index')
-            ->middleware(config('laravel-erd.middlewares'));
+            ->hasCommand(LaravelERDCommand::class)
+            ->hasRoutes('web');
     }
 }


### PR DESCRIPTION
Currently, routes registering is not working nicely since `config('laravel-erd.url')` is not readed correctly on service provider:

```php
<?php

namespace Kevincobain2000\LaravelERD;

use Spatie\LaravelPackageTools\Package;
use Spatie\LaravelPackageTools\PackageServiceProvider;
use Kevincobain2000\LaravelERD\Commands\LaravelERDCommand;
use Route;

class LaravelERDServiceProvider extends PackageServiceProvider
{
    public function configurePackage(Package $package): void
    {
        $package
            ->name('laravel-erd')
            ->hasConfigFile('laravel-erd')
            ->hasViews()
            ->hasCommand(LaravelERDCommand::class);

        // TRY TO LOG VALUE OF config('laravel-erd.url') HERE, IT WILL BE NULL.
        
        Route::get(config('laravel-erd.url'), [\Kevincobain2000\LaravelERD\Controllers\LaravelERDController::class, 'index'])
            ->name('laravel-erd.index')
            ->middleware(config('laravel-erd.middlewares'));
    }
}
```

This PR introduces routes configuration as documented by  [spatie/laravel-package-tools](https://github.com/spatie/laravel-package-tools#working-with-routes) to fix route registering.