### PR TITLE
add models from subdirectories Fix #15

### DIFF
--- a/src/LaravelERD.php
+++ b/src/LaravelERD.php
@@ -18,7 +18,7 @@ class LaravelERD
     {
         return collect(File::allFiles($modelsPath))
             ->map(function ($item) {
-                $path = $item->getRelativePathName();
+                $path = $item->getFilename();
                 $namespace = $this->extractNamespace($item->getRealPath()) . '\\';
                 $class = sprintf(
                     '\%s%s',


### PR DESCRIPTION
- Fixed sub models not appearing in diagram issue 
- Original issue was due to twice sub folder name was appearing in class path